### PR TITLE
Add Spotify upload agent for Podiatry Marketing episodes

### DIFF
--- a/apps/spotify-upload-agent/.env.example
+++ b/apps/spotify-upload-agent/.env.example
@@ -1,0 +1,21 @@
+# Descript credentials
+DESCRIPT_EMAIL=your-email@example.com
+DESCRIPT_PASSWORD=your-password
+
+# Spotify for Creators credentials
+SPOTIFY_EMAIL=your-email@example.com
+SPOTIFY_PASSWORD=your-password
+
+# Descript project settings
+DESCRIPT_PROJECT_NAME=Podiatry Marketing
+
+# Export settings
+DOWNLOAD_DIR=./downloads
+EXPORT_FORMAT=mp4
+EXPORT_QUALITY=high
+
+# Browser settings (set to true to see the browser during automation)
+HEADLESS=true
+
+# Anthropic API key (for AI-assisted episode metadata)
+ANTHROPIC_API_KEY=sk-ant-...

--- a/apps/spotify-upload-agent/.gitignore
+++ b/apps/spotify-upload-agent/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+downloads/
+.env
+.auth/

--- a/apps/spotify-upload-agent/package.json
+++ b/apps/spotify-upload-agent/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@base-org/spotify-upload-agent",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Browser automation agent to download episodes from Descript and upload to Spotify for Creators",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "download": "ts-node src/descript/download.ts",
+    "upload": "ts-node src/spotify/upload.ts",
+    "auth:descript": "ts-node src/descript/auth.ts",
+    "auth:spotify": "ts-node src/spotify/auth.ts",
+    "lint": "eslint src --ext .ts",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "playwright": "^1.41.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/spotify-upload-agent/src/config.ts
+++ b/apps/spotify-upload-agent/src/config.ts
@@ -1,0 +1,45 @@
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+function requireEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable: ${key}. Copy .env.example to .env and fill in your values.`,
+    );
+  }
+  return value;
+}
+
+export const config = {
+  descript: {
+    email: requireEnv('DESCRIPT_EMAIL'),
+    password: requireEnv('DESCRIPT_PASSWORD'),
+    projectName: process.env.DESCRIPT_PROJECT_NAME ?? 'Podiatry Marketing',
+    baseUrl: 'https://web.descript.com',
+  },
+
+  spotify: {
+    email: requireEnv('SPOTIFY_EMAIL'),
+    password: requireEnv('SPOTIFY_PASSWORD'),
+    baseUrl: 'https://creators.spotify.com',
+  },
+
+  export: {
+    downloadDir: path.resolve(
+      process.env.DOWNLOAD_DIR ?? path.join(__dirname, '../downloads'),
+    ),
+    format: (process.env.EXPORT_FORMAT ?? 'mp4') as 'mp4' | 'mov',
+    quality: (process.env.EXPORT_QUALITY ?? 'high') as 'high' | 'medium' | 'low',
+  },
+
+  browser: {
+    headless: process.env.HEADLESS !== 'false',
+    slowMo: parseInt(process.env.SLOW_MO ?? '0', 10),
+    authStateDir: path.resolve(__dirname, '../.auth'),
+  },
+} as const;
+
+export type Config = typeof config;

--- a/apps/spotify-upload-agent/src/descript/auth.ts
+++ b/apps/spotify-upload-agent/src/descript/auth.ts
@@ -1,0 +1,90 @@
+import { Page, BrowserContext } from 'playwright';
+import { config } from '../config';
+import { launchBrowser, saveAuthState } from '../utils/browser';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('descript:auth');
+
+/**
+ * Checks whether the current page session is already authenticated with Descript.
+ */
+export async function isLoggedIn(page: Page): Promise<boolean> {
+  try {
+    await page.goto(config.descript.baseUrl, { waitUntil: 'networkidle' });
+    // If we land on the dashboard / drive page, we are logged in
+    const url = page.url();
+    return url.includes('/drive') || url.includes('/projects') || url.includes('/home');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Logs into Descript using email + password through the web UI.
+ * Handles the Google OAuth flow if the login page redirects there.
+ */
+export async function loginToDescript(
+  page: Page,
+  context: BrowserContext,
+): Promise<void> {
+  log.info('Navigating to Descript login...');
+  await page.goto(`${config.descript.baseUrl}/login`, { waitUntil: 'networkidle' });
+
+  // Check if already logged in
+  if (page.url().includes('/drive') || page.url().includes('/home')) {
+    log.info('Already logged in to Descript');
+    return;
+  }
+
+  log.info('Entering credentials...');
+
+  // Descript login form: email field
+  const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email" i]');
+  await emailInput.waitFor({ state: 'visible', timeout: 15_000 });
+  await emailInput.fill(config.descript.email);
+
+  // Click continue / next if there is a two-step form
+  const continueBtn = page.locator('button:has-text("Continue"), button:has-text("Next"), button[type="submit"]').first();
+  await continueBtn.click();
+
+  // Password field (may appear after clicking continue)
+  const passwordInput = page.locator('input[type="password"]');
+  await passwordInput.waitFor({ state: 'visible', timeout: 15_000 });
+  await passwordInput.fill(config.descript.password);
+
+  // Submit login
+  const loginBtn = page.locator('button:has-text("Log in"), button:has-text("Sign in"), button[type="submit"]').first();
+  await loginBtn.click();
+
+  // Wait for navigation to the dashboard
+  await page.waitForURL(/\/(drive|projects|home)/, { timeout: 30_000 });
+  log.info('Successfully logged in to Descript');
+
+  // Save auth state for future runs
+  await saveAuthState(context, 'descript');
+}
+
+/**
+ * Standalone script: run `yarn auth:descript` to interactively log in
+ * and save the auth state for future headless runs.
+ */
+async function main() {
+  log.info('Starting Descript authentication (visible browser)...');
+  log.info('This will save your session so future runs can be headless.');
+
+  const session = await launchBrowser('descript');
+
+  try {
+    await loginToDescript(session.page, session.context);
+    log.info('Auth state saved. You can now run the agent in headless mode.');
+  } finally {
+    await session.close();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    log.error('Authentication failed', err);
+    process.exit(1);
+  });
+}

--- a/apps/spotify-upload-agent/src/descript/download.ts
+++ b/apps/spotify-upload-agent/src/descript/download.ts
@@ -1,0 +1,213 @@
+import { Page, BrowserContext } from 'playwright';
+import path from 'path';
+import fs from 'fs';
+import { config } from '../config';
+import { launchBrowser, waitForDownload, retry } from '../utils/browser';
+import { createLogger } from '../utils/logger';
+import { loginToDescript, isLoggedIn } from './auth';
+
+const log = createLogger('descript:download');
+
+export interface DescriptEpisode {
+  /** The name of the composition/episode as shown in Descript */
+  name: string;
+  /** URL to the project in Descript web */
+  url: string;
+}
+
+/**
+ * Navigates to the Descript project (e.g. "Podiatry Marketing") and returns
+ * a list of compositions (episodes) found inside it.
+ */
+export async function listEpisodes(page: Page): Promise<DescriptEpisode[]> {
+  log.info(`Looking for project: "${config.descript.projectName}"...`);
+
+  // Navigate to the drive / projects page
+  await page.goto(`${config.descript.baseUrl}/drive`, { waitUntil: 'networkidle' });
+
+  // Click into the target project folder
+  const projectLink = page.locator(
+    `[data-testid="project-name"]:has-text("${config.descript.projectName}"), ` +
+    `a:has-text("${config.descript.projectName}"), ` +
+    `div[role="button"]:has-text("${config.descript.projectName}"), ` +
+    `span:has-text("${config.descript.projectName}")`,
+  ).first();
+
+  await projectLink.waitFor({ state: 'visible', timeout: 15_000 });
+  await projectLink.click();
+  await page.waitForLoadState('networkidle');
+
+  log.info('Entered project, scanning for compositions...');
+
+  // Gather all composition / episode entries visible in the project
+  // Descript shows compositions as cards or list items
+  const compositionLocators = page.locator(
+    '[data-testid="composition-item"], ' +
+    '[class*="composition"], ' +
+    '[class*="CompositionCard"], ' +
+    '[role="listitem"]',
+  );
+
+  await compositionLocators.first().waitFor({ state: 'visible', timeout: 15_000 });
+  const count = await compositionLocators.count();
+
+  const episodes: DescriptEpisode[] = [];
+  for (let i = 0; i < count; i++) {
+    const el = compositionLocators.nth(i);
+    const name = await el.innerText();
+    // Try to extract the href, fall back to a placeholder
+    const link = await el.locator('a').first().getAttribute('href').catch(() => null);
+    episodes.push({
+      name: name.trim().split('\n')[0], // First line is typically the title
+      url: link ? new URL(link, config.descript.baseUrl).href : page.url(),
+    });
+  }
+
+  log.info(`Found ${episodes.length} episode(s) in "${config.descript.projectName}"`);
+  return episodes;
+}
+
+/**
+ * Downloads a single episode as an MP4 video from Descript.
+ * Uses the Descript web UI export flow:
+ *   1. Open the composition
+ *   2. Click File > Export (or the export button)
+ *   3. Select video format + quality
+ *   4. Wait for render + download
+ *
+ * Returns the local file path of the downloaded video.
+ */
+export async function downloadEpisode(
+  page: Page,
+  episode: DescriptEpisode,
+): Promise<string> {
+  log.info(`Downloading episode: "${episode.name}"...`);
+
+  // Navigate to the episode's composition
+  await page.goto(episode.url, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2000); // Let the editor fully load
+
+  // Open the export dialog via the Share/Export button or File menu
+  // Strategy 1: Look for an Export button in the toolbar
+  const exportBtn = page.locator(
+    'button:has-text("Export"), button:has-text("Share"), ' +
+    '[data-testid="export-button"], [aria-label="Export"]',
+  ).first();
+
+  const exportBtnVisible = await exportBtn.isVisible().catch(() => false);
+
+  if (exportBtnVisible) {
+    await exportBtn.click();
+  } else {
+    // Strategy 2: Use the File menu
+    log.info('Export button not found directly, trying File menu...');
+    const fileMenu = page.locator('button:has-text("File"), [data-testid="file-menu"]').first();
+    await fileMenu.click();
+    await page.locator('text=Export').first().click();
+  }
+
+  await page.waitForTimeout(1000);
+
+  // Select video export format
+  const videoOption = page.locator(
+    'button:has-text("Video"), [data-testid="export-video"], ' +
+    'label:has-text("Video"), div[role="tab"]:has-text("Video")',
+  ).first();
+  const videoOptionVisible = await videoOption.isVisible().catch(() => false);
+  if (videoOptionVisible) {
+    await videoOption.click();
+    await page.waitForTimeout(500);
+  }
+
+  // Select quality if a dropdown or option exists
+  if (config.export.quality === 'high') {
+    const qualitySelector = page.locator(
+      'select:near(:text("Quality")), [data-testid="quality-select"]',
+    ).first();
+    const qualityVisible = await qualitySelector.isVisible().catch(() => false);
+    if (qualityVisible) {
+      await qualitySelector.selectOption({ label: /high/i.source });
+    }
+  }
+
+  // Click the final Export / Download button
+  const finalExportBtn = page.locator(
+    'button:has-text("Export"), button:has-text("Download"), ' +
+    '[data-testid="export-submit"], [data-testid="download-button"]',
+  ).last();
+  await finalExportBtn.click();
+
+  log.info('Export started, waiting for render and download...');
+
+  // Wait for the file to download (rendering may take several minutes)
+  const filePath = await waitForDownload(page);
+
+  log.info(`Episode "${episode.name}" downloaded to: ${filePath}`);
+  return filePath;
+}
+
+/**
+ * Downloads all episodes from the Descript project that haven't been
+ * downloaded yet (checks the downloads directory for existing files).
+ */
+export async function downloadNewEpisodes(
+  page: Page,
+  context: BrowserContext,
+): Promise<{ episode: DescriptEpisode; filePath: string }[]> {
+  // Ensure we're logged in
+  if (!(await isLoggedIn(page))) {
+    await loginToDescript(page, context);
+  }
+
+  const episodes = await listEpisodes(page);
+  const results: { episode: DescriptEpisode; filePath: string }[] = [];
+
+  // Check which episodes already exist in the download directory
+  const existingFiles = fs.existsSync(config.export.downloadDir)
+    ? new Set(fs.readdirSync(config.export.downloadDir).map((f) => f.toLowerCase()))
+    : new Set<string>();
+
+  for (const episode of episodes) {
+    const sanitizedName = episode.name.replace(/[^a-zA-Z0-9_\- ]/g, '').toLowerCase();
+    const alreadyDownloaded = [...existingFiles].some((f) =>
+      f.includes(sanitizedName),
+    );
+
+    if (alreadyDownloaded) {
+      log.info(`Skipping "${episode.name}" (already downloaded)`);
+      continue;
+    }
+
+    try {
+      const filePath = await retry(() => downloadEpisode(page, episode));
+      results.push({ episode, filePath });
+    } catch (err) {
+      log.error(`Failed to download "${episode.name}"`, err);
+    }
+  }
+
+  log.info(`Downloaded ${results.length} new episode(s)`);
+  return results;
+}
+
+/**
+ * Standalone script: run `yarn download` to download episodes from Descript.
+ */
+async function main() {
+  const session = await launchBrowser('descript');
+  try {
+    const results = await downloadNewEpisodes(session.page, session.context);
+    for (const { episode, filePath } of results) {
+      log.info(`✓ ${episode.name} → ${filePath}`);
+    }
+  } finally {
+    await session.close();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    log.error('Download failed', err);
+    process.exit(1);
+  });
+}

--- a/apps/spotify-upload-agent/src/index.ts
+++ b/apps/spotify-upload-agent/src/index.ts
@@ -1,0 +1,86 @@
+import { config } from './config';
+import { launchBrowser } from './utils/browser';
+import { createLogger } from './utils/logger';
+import { downloadNewEpisodes } from './descript/download';
+import { uploadNewEpisodes } from './spotify/upload';
+
+const log = createLogger('agent');
+
+/**
+ * Main orchestrator: downloads new episodes from Descript, then uploads
+ * them to Spotify for Creators.
+ *
+ * Usage:
+ *   yarn start              # Run the full pipeline
+ *   yarn download           # Only download from Descript
+ *   yarn upload             # Only upload to Spotify
+ *   yarn auth:descript      # Save Descript login session
+ *   yarn auth:spotify       # Save Spotify login session
+ */
+async function main() {
+  log.info('=== Spotify Upload Agent ===');
+  log.info(`Project: ${config.descript.projectName}`);
+  log.info(`Download directory: ${config.export.downloadDir}`);
+  log.info(`Headless mode: ${config.browser.headless}`);
+  log.info('');
+
+  // --- Phase 1: Download from Descript ---
+  log.info('--- Phase 1: Downloading episodes from Descript ---');
+  const descriptSession = await launchBrowser('descript');
+  let downloadedFiles: string[] = [];
+
+  try {
+    const results = await downloadNewEpisodes(
+      descriptSession.page,
+      descriptSession.context,
+    );
+    downloadedFiles = results.map((r) => r.filePath);
+
+    if (results.length === 0) {
+      log.info('No new episodes to download from Descript');
+    } else {
+      log.info(`Downloaded ${results.length} episode(s):`);
+      for (const { episode, filePath } of results) {
+        log.info(`  - ${episode.name} → ${filePath}`);
+      }
+    }
+  } catch (err) {
+    log.error('Descript download phase failed', err);
+    throw err;
+  } finally {
+    await descriptSession.close();
+  }
+
+  // --- Phase 2: Upload to Spotify for Creators ---
+  log.info('');
+  log.info('--- Phase 2: Uploading episodes to Spotify for Creators ---');
+  const spotifySession = await launchBrowser('spotify');
+
+  try {
+    // Upload the newly downloaded files (or any pending files in the downloads dir)
+    const uploaded = await uploadNewEpisodes(
+      spotifySession.page,
+      spotifySession.context,
+      downloadedFiles.length > 0 ? downloadedFiles : undefined,
+    );
+
+    if (uploaded.length === 0) {
+      log.info('No new episodes to upload to Spotify');
+    } else {
+      log.info(`Uploaded ${uploaded.length} episode(s) to Spotify for Creators`);
+    }
+  } catch (err) {
+    log.error('Spotify upload phase failed', err);
+    throw err;
+  } finally {
+    await spotifySession.close();
+  }
+
+  log.info('');
+  log.info('=== Agent run complete ===');
+}
+
+main().catch((err) => {
+  log.error('Agent failed', err);
+  process.exit(1);
+});

--- a/apps/spotify-upload-agent/src/spotify/auth.ts
+++ b/apps/spotify-upload-agent/src/spotify/auth.ts
@@ -1,0 +1,96 @@
+import { Page, BrowserContext } from 'playwright';
+import { config } from '../config';
+import { launchBrowser, saveAuthState } from '../utils/browser';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('spotify:auth');
+
+/**
+ * Checks whether the current session is authenticated with Spotify for Creators.
+ */
+export async function isLoggedIn(page: Page): Promise<boolean> {
+  try {
+    await page.goto(`${config.spotify.baseUrl}/dashboard`, {
+      waitUntil: 'networkidle',
+    });
+    const url = page.url();
+    // If we stay on dashboard (not redirected to login), we're authenticated
+    return url.includes('/dashboard') || url.includes('/episodes');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Logs into Spotify for Creators using email + password.
+ */
+export async function loginToSpotify(
+  page: Page,
+  context: BrowserContext,
+): Promise<void> {
+  log.info('Navigating to Spotify for Creators login...');
+  await page.goto(`${config.spotify.baseUrl}/dashboard`, {
+    waitUntil: 'networkidle',
+  });
+
+  // Check if already logged in
+  const url = page.url();
+  if (url.includes('/dashboard') && !url.includes('login')) {
+    log.info('Already logged in to Spotify for Creators');
+    return;
+  }
+
+  log.info('Entering Spotify credentials...');
+
+  // Spotify login form
+  const emailInput = page.locator(
+    'input[id="login-username"], input[name="username"], input[type="email"], input[placeholder*="email" i]',
+  );
+  await emailInput.waitFor({ state: 'visible', timeout: 15_000 });
+  await emailInput.fill(config.spotify.email);
+
+  const passwordInput = page.locator(
+    'input[id="login-password"], input[name="password"], input[type="password"]',
+  );
+  await passwordInput.waitFor({ state: 'visible', timeout: 15_000 });
+  await passwordInput.fill(config.spotify.password);
+
+  // Click login button
+  const loginBtn = page.locator(
+    'button[id="login-button"], button:has-text("Log In"), button:has-text("Sign in"), button[type="submit"]',
+  ).first();
+  await loginBtn.click();
+
+  // Wait for redirect to dashboard
+  await page.waitForURL(/\/(dashboard|episodes|home)/, { timeout: 30_000 });
+  log.info('Successfully logged in to Spotify for Creators');
+
+  await saveAuthState(context, 'spotify');
+}
+
+/**
+ * Standalone script: run `yarn auth:spotify` to interactively log in
+ * and save the auth state for future headless runs.
+ */
+async function main() {
+  log.info('Starting Spotify for Creators authentication (visible browser)...');
+  log.info('This will save your session so future runs can be headless.');
+
+  // Force visible browser for initial auth
+  process.env.HEADLESS = 'false';
+  const session = await launchBrowser('spotify');
+
+  try {
+    await loginToSpotify(session.page, session.context);
+    log.info('Auth state saved. You can now run the agent in headless mode.');
+  } finally {
+    await session.close();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    log.error('Authentication failed', err);
+    process.exit(1);
+  });
+}

--- a/apps/spotify-upload-agent/src/spotify/upload.ts
+++ b/apps/spotify-upload-agent/src/spotify/upload.ts
@@ -1,0 +1,295 @@
+import { Page, BrowserContext } from 'playwright';
+import path from 'path';
+import fs from 'fs';
+import { config } from '../config';
+import { launchBrowser, retry } from '../utils/browser';
+import { createLogger } from '../utils/logger';
+import { loginToSpotify, isLoggedIn } from './auth';
+
+const log = createLogger('spotify:upload');
+
+export interface EpisodeMetadata {
+  /** Episode title */
+  title: string;
+  /** Episode description */
+  description: string;
+  /** Season number (optional) */
+  season?: number;
+  /** Episode number (optional) */
+  episodeNumber?: number;
+  /** Whether to publish immediately or save as draft */
+  publishImmediately: boolean;
+}
+
+/**
+ * Extracts episode metadata from the filename and an optional sidecar JSON.
+ *
+ * Convention: if `episode.mp4` has a matching `episode.json` next to it,
+ * that JSON is used for title, description, etc. Otherwise sensible
+ * defaults are generated from the filename.
+ */
+export function getEpisodeMetadata(filePath: string): EpisodeMetadata {
+  const baseName = path.basename(filePath, path.extname(filePath));
+  const jsonPath = path.join(path.dirname(filePath), `${baseName}.json`);
+
+  if (fs.existsSync(jsonPath)) {
+    log.info(`Loading metadata from ${jsonPath}`);
+    const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
+    return {
+      title: raw.title ?? baseName,
+      description: raw.description ?? '',
+      season: raw.season,
+      episodeNumber: raw.episodeNumber,
+      publishImmediately: raw.publishImmediately ?? false,
+    };
+  }
+
+  // Generate from filename: "EP03 - Patient Retention Tips" → title
+  const titleMatch = baseName.match(/^(?:EP?\s*\d+\s*[-–—]\s*)?(.+)$/i);
+  const title = titleMatch ? titleMatch[1].trim() : baseName;
+
+  // Try to extract episode number from filename
+  const epMatch = baseName.match(/EP?\s*(\d+)/i);
+  const episodeNumber = epMatch ? parseInt(epMatch[1], 10) : undefined;
+
+  return {
+    title,
+    description: `${title} - Podiatry Marketing`,
+    episodeNumber,
+    publishImmediately: false, // Default to draft for safety
+  };
+}
+
+/**
+ * Uploads a video episode to Spotify for Creators through the web UI.
+ *
+ * Flow:
+ *   1. Navigate to the new episode page
+ *   2. Upload the video file
+ *   3. Fill in title, description, and other metadata
+ *   4. Either publish or save as draft
+ */
+export async function uploadEpisode(
+  page: Page,
+  filePath: string,
+  metadata: EpisodeMetadata,
+): Promise<void> {
+  log.info(`Uploading episode: "${metadata.title}" from ${filePath}`);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  // Navigate to the new episode creation page
+  await page.goto(`${config.spotify.baseUrl}/dashboard/episodes/new`, {
+    waitUntil: 'networkidle',
+  });
+  await page.waitForTimeout(2000);
+
+  // -- Step 1: Upload the video file --
+  log.info('Uploading video file...');
+
+  // Spotify for Creators has a file input for episode upload
+  // Look for the file input element (may be hidden behind a button)
+  const fileInput = page.locator(
+    'input[type="file"], input[accept*="video"], input[accept*="audio"]',
+  ).first();
+  const fileInputVisible = await fileInput.isVisible().catch(() => false);
+
+  if (fileInputVisible) {
+    await fileInput.setInputFiles(filePath);
+  } else {
+    // Some UIs hide the input, look for an upload area
+    const uploadBtn = page.locator(
+      'button:has-text("Upload"), button:has-text("Select a file"), ' +
+      'button:has-text("Choose file"), [data-testid="upload-button"]',
+    ).first();
+    await uploadBtn.click();
+
+    // After clicking, the hidden file input should become actionable
+    const hiddenInput = page.locator('input[type="file"]').first();
+    await hiddenInput.setInputFiles(filePath);
+  }
+
+  // Wait for the upload to complete (can take a while for large video files)
+  log.info('Waiting for upload to complete...');
+  await page.waitForSelector(
+    '[data-testid="upload-complete"], ' +
+    ':text("Upload complete"), :text("uploaded"), ' +
+    ':text("Processing"), progress[value="100"]',
+    { timeout: 600_000 }, // 10 minutes for large files
+  );
+  log.info('Upload complete');
+
+  // -- Step 2: Fill in episode metadata --
+  log.info('Filling in episode metadata...');
+
+  // Title field
+  const titleInput = page.locator(
+    'input[name="title"], input[placeholder*="title" i], ' +
+    '[data-testid="episode-title"], input[aria-label*="title" i]',
+  ).first();
+  await titleInput.waitFor({ state: 'visible', timeout: 10_000 });
+  await titleInput.fill(metadata.title);
+
+  // Description field
+  const descInput = page.locator(
+    'textarea[name="description"], [contenteditable="true"], ' +
+    'textarea[placeholder*="description" i], [data-testid="episode-description"]',
+  ).first();
+  const descVisible = await descInput.isVisible().catch(() => false);
+  if (descVisible) {
+    await descInput.fill(metadata.description);
+  }
+
+  // Episode number (if available and field exists)
+  if (metadata.episodeNumber !== undefined) {
+    const epNumInput = page.locator(
+      'input[name*="episode" i][name*="number" i], ' +
+      'input[placeholder*="episode number" i], ' +
+      '[data-testid="episode-number"]',
+    ).first();
+    const epNumVisible = await epNumInput.isVisible().catch(() => false);
+    if (epNumVisible) {
+      await epNumInput.fill(String(metadata.episodeNumber));
+    }
+  }
+
+  // Season number (if available and field exists)
+  if (metadata.season !== undefined) {
+    const seasonInput = page.locator(
+      'input[name*="season" i], input[placeholder*="season" i], ' +
+      '[data-testid="season-number"]',
+    ).first();
+    const seasonVisible = await seasonInput.isVisible().catch(() => false);
+    if (seasonVisible) {
+      await seasonInput.fill(String(metadata.season));
+    }
+  }
+
+  // -- Step 3: Publish or save as draft --
+  if (metadata.publishImmediately) {
+    log.info('Publishing episode...');
+    const publishBtn = page.locator(
+      'button:has-text("Publish"), button:has-text("Submit"), ' +
+      '[data-testid="publish-button"]',
+    ).first();
+    await publishBtn.click();
+  } else {
+    log.info('Saving as draft...');
+    const draftBtn = page.locator(
+      'button:has-text("Save as draft"), button:has-text("Save draft"), ' +
+      'button:has-text("Draft"), [data-testid="save-draft"]',
+    ).first();
+    const draftVisible = await draftBtn.isVisible().catch(() => false);
+    if (draftVisible) {
+      await draftBtn.click();
+    } else {
+      // If no explicit draft button, try the primary save/submit
+      const saveBtn = page.locator(
+        'button:has-text("Save"), button:has-text("Submit"), button[type="submit"]',
+      ).first();
+      await saveBtn.click();
+    }
+  }
+
+  // Wait for confirmation
+  await page.waitForSelector(
+    ':text("saved"), :text("published"), :text("success"), ' +
+    '[data-testid="success-message"]',
+    { timeout: 30_000 },
+  ).catch(() => {
+    log.warn('No explicit success confirmation detected, checking URL...');
+  });
+
+  // Verify by checking we redirected away from the /new page
+  const finalUrl = page.url();
+  if (finalUrl.includes('/new')) {
+    log.warn('May still be on the new episode page - check for errors');
+  } else {
+    log.info(`Episode "${metadata.title}" saved successfully`);
+  }
+}
+
+/**
+ * Uploads all video files from the downloads directory that haven't been
+ * uploaded yet. Tracks uploaded files via a manifest file.
+ */
+export async function uploadNewEpisodes(
+  page: Page,
+  context: BrowserContext,
+  filePaths?: string[],
+): Promise<string[]> {
+  // Ensure we're logged in
+  if (!(await isLoggedIn(page))) {
+    await loginToSpotify(page, context);
+  }
+
+  // Determine which files to upload
+  const files =
+    filePaths ??
+    (fs.existsSync(config.export.downloadDir)
+      ? fs
+          .readdirSync(config.export.downloadDir)
+          .filter((f) => /\.(mp4|mov)$/i.test(f))
+          .map((f) => path.join(config.export.downloadDir, f))
+      : []);
+
+  if (files.length === 0) {
+    log.info('No video files found to upload');
+    return [];
+  }
+
+  // Load the manifest of already-uploaded files
+  const manifestPath = path.join(config.export.downloadDir, '.uploaded-manifest.json');
+  const manifest: Set<string> = fs.existsSync(manifestPath)
+    ? new Set(JSON.parse(fs.readFileSync(manifestPath, 'utf-8')))
+    : new Set();
+
+  const uploaded: string[] = [];
+
+  for (const filePath of files) {
+    const fileName = path.basename(filePath);
+    if (manifest.has(fileName)) {
+      log.info(`Skipping "${fileName}" (already uploaded)`);
+      continue;
+    }
+
+    const metadata = getEpisodeMetadata(filePath);
+
+    try {
+      await retry(() => uploadEpisode(page, filePath, metadata));
+      manifest.add(fileName);
+      // Persist manifest after each successful upload
+      fs.writeFileSync(manifestPath, JSON.stringify([...manifest], null, 2));
+      uploaded.push(filePath);
+    } catch (err) {
+      log.error(`Failed to upload "${fileName}"`, err);
+    }
+  }
+
+  log.info(`Uploaded ${uploaded.length} new episode(s) to Spotify for Creators`);
+  return uploaded;
+}
+
+/**
+ * Standalone script: run `yarn upload` to upload episodes to Spotify.
+ */
+async function main() {
+  const session = await launchBrowser('spotify');
+  try {
+    const uploaded = await uploadNewEpisodes(session.page, session.context);
+    for (const f of uploaded) {
+      log.info(`✓ Uploaded: ${path.basename(f)}`);
+    }
+  } finally {
+    await session.close();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    log.error('Upload failed', err);
+    process.exit(1);
+  });
+}

--- a/apps/spotify-upload-agent/src/utils/browser.ts
+++ b/apps/spotify-upload-agent/src/utils/browser.ts
@@ -1,0 +1,114 @@
+import { chromium, Browser, BrowserContext, Page } from 'playwright';
+import path from 'path';
+import fs from 'fs';
+import { config } from '../config';
+import { createLogger } from './logger';
+
+const log = createLogger('browser');
+
+export interface BrowserSession {
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+  close: () => Promise<void>;
+}
+
+/**
+ * Launches a Playwright browser with persistent auth state support.
+ * Auth state is saved per-service so Descript and Spotify sessions are independent.
+ */
+export async function launchBrowser(
+  service: 'descript' | 'spotify',
+): Promise<BrowserSession> {
+  const authStatePath = path.join(config.browser.authStateDir, `${service}.json`);
+
+  log.info(`Launching browser for ${service} (headless: ${config.browser.headless})`);
+
+  const browser = await chromium.launch({
+    headless: config.browser.headless,
+    slowMo: config.browser.slowMo,
+  });
+
+  // Restore saved auth state if available
+  const hasAuthState = fs.existsSync(authStatePath);
+  const context = await browser.newContext({
+    ...(hasAuthState ? { storageState: authStatePath } : {}),
+    acceptDownloads: true,
+    viewport: { width: 1280, height: 800 },
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+  });
+
+  if (hasAuthState) {
+    log.info(`Restored auth state for ${service} from ${authStatePath}`);
+  }
+
+  const page = await context.newPage();
+
+  return {
+    browser,
+    context,
+    page,
+    async close() {
+      await context.close();
+      await browser.close();
+    },
+  };
+}
+
+/**
+ * Saves the current browser auth state (cookies, localStorage) so future
+ * sessions can skip the login flow.
+ */
+export async function saveAuthState(
+  context: BrowserContext,
+  service: 'descript' | 'spotify',
+): Promise<void> {
+  const authDir = config.browser.authStateDir;
+  if (!fs.existsSync(authDir)) {
+    fs.mkdirSync(authDir, { recursive: true });
+  }
+  const authStatePath = path.join(authDir, `${service}.json`);
+  await context.storageState({ path: authStatePath });
+  log.info(`Saved auth state for ${service}`);
+}
+
+/**
+ * Waits for a file to finish downloading by watching for the download event.
+ */
+export async function waitForDownload(page: Page): Promise<string> {
+  const download = await page.waitForEvent('download', { timeout: 300_000 });
+  const downloadPath = path.join(
+    config.export.downloadDir,
+    download.suggestedFilename(),
+  );
+
+  if (!fs.existsSync(config.export.downloadDir)) {
+    fs.mkdirSync(config.export.downloadDir, { recursive: true });
+  }
+
+  await download.saveAs(downloadPath);
+  log.info(`Downloaded file to ${downloadPath}`);
+  return downloadPath;
+}
+
+/**
+ * Retry helper for flaky browser interactions. Retries up to `attempts` times
+ * with a short delay between each attempt.
+ */
+export async function retry<T>(
+  fn: () => Promise<T>,
+  attempts: number = 3,
+  delayMs: number = 2000,
+): Promise<T> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (i === attempts - 1) throw err;
+      log.warn(`Attempt ${i + 1} failed, retrying in ${delayMs}ms...`, err);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error('Unreachable');
+}

--- a/apps/spotify-upload-agent/src/utils/logger.ts
+++ b/apps/spotify-upload-agent/src/utils/logger.ts
@@ -1,0 +1,34 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LOG_COLORS: Record<LogLevel, string> = {
+  debug: '\x1b[90m',
+  info: '\x1b[36m',
+  warn: '\x1b[33m',
+  error: '\x1b[31m',
+};
+
+const RESET = '\x1b[0m';
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+function log(level: LogLevel, context: string, message: string, data?: unknown): void {
+  const color = LOG_COLORS[level];
+  const prefix = `${color}[${timestamp()}] [${level.toUpperCase()}] [${context}]${RESET}`;
+
+  if (data !== undefined) {
+    console.log(`${prefix} ${message}`, data);
+  } else {
+    console.log(`${prefix} ${message}`);
+  }
+}
+
+export function createLogger(context: string) {
+  return {
+    debug: (message: string, data?: unknown) => log('debug', context, message, data),
+    info: (message: string, data?: unknown) => log('info', context, message, data),
+    warn: (message: string, data?: unknown) => log('warn', context, message, data),
+    error: (message: string, data?: unknown) => log('error', context, message, data),
+  };
+}

--- a/apps/spotify-upload-agent/tsconfig.json
+++ b/apps/spotify-upload-agent/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Browser automation agent using Playwright to download completed episode
videos from Descript and upload them to Spotify for Creators. Neither
platform offers a public API for export/upload, so this uses UI automation.

Components:
- Descript download agent: logs in, navigates to project, exports episodes
- Spotify upload agent: logs in, uploads video with metadata, saves as draft
- Main orchestrator: runs both phases sequentially
- Auth persistence: saves browser sessions to skip login on repeat runs
- Episode manifest: tracks uploaded files to avoid duplicates

https://claude.ai/code/session_01TT1aavATxCz8XktnxkYS4N